### PR TITLE
Change controllers sample code to initialize messages array

### DIFF
--- a/jade/blog/angular-socket-io.md
+++ b/jade/blog/angular-socket-io.md
@@ -218,6 +218,8 @@ function AppCtrl($scope, socket) {
     });
   };
 
+  $scope.messages = [];
+
   $scope.sendMessage = function () {
     socket.emit('send:message', {
       message: $scope.message


### PR DESCRIPTION
Walking through the tutorial, I was getting a client script error due to the messages array not being initialized in the controller. I've copied code from the [demo](https://github.com/btford/angular-socket-io-im) repo. 
